### PR TITLE
[Release] 스터디 생성시 태그 중복 입력 무효처리#28

### DIFF
--- a/src/components/createStudy/CreateStudyTag.tsx
+++ b/src/components/createStudy/CreateStudyTag.tsx
@@ -14,7 +14,7 @@ const CreateStudyTag = () => {
   }
 
   const onClickTagButton = () => {
-    const newTagData = [...tagData, tagValue]
+    const newTagData = [...new Set([...tagData, tagValue])]
     dispatch(changeStudyForm({ key: 'tags', value: newTagData }))
     setTagValue('')
   }
@@ -37,15 +37,13 @@ const CreateStudyTag = () => {
         </InputWrapper>
       </>
       <TagWrapper>
-        {tagData.map((tag, index) => (
-          <>
-            <Tag id={tag} key={index}>
-              #{tag}
-            </Tag>
-            <RemoveButton id={tag} key={index + 1} type="button" onClick={onClickRemoveTag}>
+        {tagData.map((tag) => (
+          <Tag key={tag}>
+            <TagText id={tag}>#{tag}</TagText>
+            <RemoveButton id={tag} type="button" onClick={onClickRemoveTag}>
               <AiOutlineDelete />
             </RemoveButton>
-          </>
+          </Tag>
         ))}
       </TagWrapper>
     </Container>
@@ -95,8 +93,11 @@ const TagWrapper = styled.div`
   align-items: center;
   margin-top: 1.5rem;
 `
-
 const Tag = styled.div`
+  display: flex;
+  align-items: center;
+`
+const TagText = styled.div`
   height: 2rem;
   margin-right: 0.5rem;
   padding: 0.1rem 1rem 0 1rem;

--- a/src/lib/api/httpClient.ts
+++ b/src/lib/api/httpClient.ts
@@ -1,10 +1,9 @@
-import axios, { AxiosInstance, AxiosRequestConfig, InternalAxiosRequestConfig } from 'axios'
+import axios, { AxiosInstance, InternalAxiosRequestConfig } from 'axios'
 import { getLocalStorageToken } from '../util/localStorage'
 
 declare module 'axios' {
   type AxiosRequest<T> = Promise<T>
 }
-
 abstract class HttpClient {
   protected readonly instance: AxiosInstance
 

--- a/src/pages/sign/SignIn/index.tsx
+++ b/src/pages/sign/SignIn/index.tsx
@@ -1,6 +1,6 @@
 import { ChangeEvent, FormEvent, useEffect } from 'react'
 import { SignInParam } from 'src/lib/types/UserInterface'
-import { allClearSignInForm, changeSignInForm, isSignInValidation, postSignInForm } from 'src/lib/store/auth/authSlice'
+import { allClearSignInForm, changeSignInForm, isSignInValidation } from 'src/lib/store/auth/authSlice'
 import { useNavigate } from 'react-router-dom'
 import { GITHUB_LOGIN_URL } from 'src/lib/constants/Url'
 import { useAppDispatch, useAppSelector } from 'src/lib/hooks'

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,6 +1,6 @@
 {
   "compilerOptions": {
-    "target": "es5",
+    "target": "es2015",
     "lib": [
       "dom",
       "dom.iterable",


### PR DESCRIPTION
## 🔎 What is this PR?

- 스터디 생성시 태그를 중복 입력했을 때 무효처리 됩니다.

## 🔑 Key Changes
**[CreateStudyTag.tsx]**
* `Set` 함수를 사용해서 중복 데이터를 필터링했습니다.

```tsx
  const onClickTagButton = () => {
    const newTagData = [...new Set([...tagData, tagValue])]
    dispatch(changeStudyForm({ key: 'tags', value: newTagData }))
    setTagValue('')
  }
```

