### PR TITLE
[release] 메인페이지 스터디 필터링 기능 에러 해결

### DIFF
--- a/src/components/mainPage/StudyList.tsx
+++ b/src/components/mainPage/StudyList.tsx
@@ -16,13 +16,12 @@ const StudyList = () => {
 
   useEffect(() => {
     switch (currentStudyType) {
-      case 'study': {
+      case 'STUDY': {
         const filteredStudyResponse = studyResponses.filter((study) => study.studyType === 'STUDY')
-
         setFilterdStudies(filteredStudyResponse)
         break
       }
-      case 'mogakko': {
+      case 'MOGAKKO': {
         const filteredStudyResponse = studyResponses.filter((study) => study.studyType === 'MOGAKKO')
         setFilterdStudies(filteredStudyResponse)
         break

--- a/src/components/mainPage/StudyTypeFilter.tsx
+++ b/src/components/mainPage/StudyTypeFilter.tsx
@@ -2,11 +2,13 @@ import styled from 'styled-components'
 import { RxDividerVertical } from 'react-icons/rx'
 import { changeCurrentStudyType } from 'src/lib/store/studyListSlice'
 import { useAppDispatch, useAppSelector } from 'src/lib/hooks'
+import settingStudyTypeName from 'src/lib/util/settingStudyTypeName'
 
 const StudyTypeFilter = () => {
   const dispatch = useAppDispatch()
   const currentStudytype = useAppSelector(({ studyList }) => studyList.value.currentStudyType)
-  const studyTypeArr = ['All', 'Study', 'Mogakko']
+  const studyTypeArr = ['All', 'STUDY', 'MOGAKKO']
+
   const onClickStudyType = (e: React.MouseEvent<HTMLButtonElement>) => {
     dispatch(changeCurrentStudyType(e.currentTarget.value))
   }
@@ -25,7 +27,7 @@ const StudyTypeFilter = () => {
               active={currentStudytype === studyType}
               onClick={onClickStudyType}
             >
-              {studyType}
+              {settingStudyTypeName(studyType)}
             </StudyType>
             <DivisionLine key={`divider`}>
               <RxDividerVertical key={`divider${studyType}`} />

--- a/src/lib/util/settingStudyTypeName.ts
+++ b/src/lib/util/settingStudyTypeName.ts
@@ -1,0 +1,12 @@
+const settingStudyTypeName = (studytype: string) => {
+  switch (studytype) {
+    case 'STUDY':
+      return '스터디'
+    case 'MOGAKKO':
+      return '모각코'
+    default:
+      return 'ALL'
+  }
+}
+
+export default settingStudyTypeName

--- a/src/pages/createStudy/index.tsx
+++ b/src/pages/createStudy/index.tsx
@@ -3,7 +3,6 @@ import { Header } from 'src/components/Header'
 import { refreshTokenAPI } from 'src/lib/api/auth/refreshTokenAPI'
 import { CreateStudyTag, SelectMaxMemberCount, SelectStudyColor, ToastEditor } from 'src/components/createStudy'
 import SelectDate from 'src/components/createStudy/SelectDate'
-
 import { allClearForm, changeStudyForm } from 'src/lib/store/studyFormSlice'
 import StudyTypeSelector from 'src/components/createStudy/StudyTypeSelector'
 import { useNavigate } from 'react-router-dom'
@@ -18,6 +17,7 @@ const CreateStudy = () => {
 
   useEffect(() => {
     refreshTokenAPI.getRefreshToken()
+    dispatch(allClearForm())
   }, [])
 
   const onChangeTitle = (e: ChangeEvent<HTMLInputElement>) => {

--- a/src/pages/memberInfo/index.tsx
+++ b/src/pages/memberInfo/index.tsx
@@ -8,7 +8,6 @@ import { DefaultButton, DividingLine } from 'src/components'
 import styled from 'styled-components'
 import { TbHeartPlus, TbHeart } from 'react-icons/tb'
 import { AiOutlineUserDelete } from 'react-icons/ai'
-import { StudyWithCondition } from 'src/lib/types/StudyInterface'
 import theme from 'src/style/theme'
 import { memberAPI } from 'src/lib/api/Member/MemberAPI'
 import { removeToken } from 'src/lib/util/localStorage'
@@ -17,7 +16,6 @@ import { useNavigate } from 'react-router-dom'
 const MemberInfo = () => {
   const dispatch = useAppDispatch()
   const { studiesAppliedFor, studyParticipated } = useAppSelector((member) => member.member.value)
-  const [studiesParticipated] = useState<StudyWithCondition[]>([])
   const [isOpenUserDelete, setIsOpenUserDelete] = useState<boolean>(false)
   const navigate = useNavigate()
 


### PR DESCRIPTION
## 🔎 What is this PR?

- 메인 페이지에있는 스터디 목록을 필터링하는 기능이 작동되지 않는 에러가 발생

## 🔑 Key Changes

### ✔ 에러 원인과 해결
*  스터디 리스트에 관한 state를 관리하는 store에서 사용하는 스터디 타입 이름(STUDY)와 컴포넌트에서 사용하는 스터디 타입 이름(study)이 달라서 생긴 에러
#### [components/mainPage/StudyList.tsx]
```tsx
useEffect(() => {
    switch (currentStudyType) {
      case 'STUDY': { // study -> STUDY
        const filteredStudyResponse = studyResponses.filter((study) => study.studyType === 'STUDY')
        setFilterdStudies(filteredStudyResponse)
        break
      }
      case 'MOGAKKO': { // mogakko -> MOGAKKO
        const filteredStudyResponse = studyResponses.filter((study) => study.studyType === 'MOGAKKO')
        setFilterdStudies(filteredStudyResponse)
        break
      }
      default:
        setFilterdStudies(studyResponses)
    }
  }, [studyResponses, currentStudyType])
```

### ✔ 필터 이름을 영문에서 한글로
* 스터디는 study로 주로 사용하지만, 모각코는 영어로 사용하는 상황이 많지 않다고 생각이 들어 한글로 변경
* 이름을 바꾸어주는 util 함수 생성
#### [lib/util/setting/Study/TypeName.ts]
```ts
const settingStudyTypeName = (studytype: string) => {
  switch (studytype) {
    case 'STUDY':
      return '스터디'
    case 'MOGAKKO':
      return '모각코'
    default:
      return 'ALL'
  }
}

export default settingStudyTypeName
```

#### [component/mainPage/StudyTypeFilter]
``` tsx
{studyTypeArr.map((studyType) => (
          <span key={studyType} style={{ display: 'flex' }}>
            <StudyType
              key={studyType}
              value={studyType}
              active={currentStudytype === studyType}
              onClick={onClickStudyType}
            >
              {settingStudyTypeName(studyType)} // 함수 사용
            </StudyType>
            <DivisionLine key={`divider`}>
              <RxDividerVertical key={`divider${studyType}`} />
            </DivisionLine>
          </span>
        ))}
```

## 🙋🏻‍♀️ To Reviewers

- 코드 리뷰시 집중할 부분에 대해 설명해주세요.
-
