### PR TITLE
[Release] 프로필 수정시 이미지 업로드 안되는 현상 #33

### DIFF
--- a/src/components/member/MemberProfile/index.tsx
+++ b/src/components/member/MemberProfile/index.tsx
@@ -4,6 +4,7 @@ import { ChangeEvent, FormEvent, useCallback, useRef, useState } from 'react'
 import { changeMemberInfo, postEditedMember } from 'src/lib/store/member/memberSlice'
 import { useAppDispatch, useAppSelector } from 'src/lib/hooks'
 import { MemberFormParam } from 'src/lib/types/UserInterface'
+import { AiOutlineWarning } from 'react-icons/ai'
 import * as S from './styles'
 
 const initialEditForm = {
@@ -12,6 +13,7 @@ const initialEditForm = {
   username: '',
   imageUrl: '',
 } as Omit<MemberFormParam, 'email' & 'password'>
+
 const MemberProfile = () => {
   const dispatch = useAppDispatch()
   const { memberInfo } = useAppSelector(({ member }) => member.value)
@@ -52,6 +54,7 @@ const MemberProfile = () => {
     setMemberForm(initialEditForm)
   }
 
+  const isGithubLoginUser = () => memberInfo.githubId !== null
   return isOpenEdit ? (
     <>
       <form encType="multipart/form-data" onSubmit={onSubmitUserForm}>
@@ -102,19 +105,26 @@ const MemberProfile = () => {
       <S.Profile>
         <S.Thumbnail>
           <S.MemberImage image={memberInfo.imageUrl} />
-          <S.ImgUploadInput
-            id="ImgUpload"
-            type="file"
-            accept="image/*"
-            onChange={onChangeProfileImg}
-            ref={imgInputRef}
-          />
         </S.Thumbnail>
         <S.MemberInfo>
           <S.Name>{memberInfo.username}</S.Name>
           <S.Email>{memberInfo.email === 'null' ? '' : memberInfo.email}</S.Email>
-          <S.EditButton type="button" onClick={() => setIsOpenEdit(true)}>
-            회원정보 수정
+          <S.EditButton type="button" onClick={() => setIsOpenEdit(true)} disabled={isGithubLoginUser()}>
+            {isGithubLoginUser() ? (
+              <>
+                <AiOutlineWarning style={{ marginRight: '1rem' }} />
+                <h5 style={{ textAlign: 'left' }}>
+                  깃허브 로그인 사용자는 회원정보 수정이 불가합니다.
+                  <br />
+                  <a style={{ textDecoration: 'none' }} href={memberInfo.profileUrl}>
+                    깃허브 페이지
+                  </a>
+                  에서 회원정보를 수정해주세요.
+                </h5>
+              </>
+            ) : (
+              <h5>회원정보 수정</h5>
+            )}
           </S.EditButton>
         </S.MemberInfo>
       </S.Profile>

--- a/src/components/member/MemberProfile/index.tsx
+++ b/src/components/member/MemberProfile/index.tsx
@@ -1,23 +1,22 @@
 import DefaultButton from 'src/components/DefaultButton'
 import theme from 'src/style/theme'
-import { ChangeEvent, FormEvent, useCallback, useRef, useState } from 'react'
-import { changeMemberInfo, postEditedMember } from 'src/lib/store/member/memberSlice'
+import { ChangeEvent, FormEvent, useCallback, useEffect, useRef, useState } from 'react'
+import { changeMemberInfo } from 'src/lib/store/member/memberSlice'
 import { useAppDispatch, useAppSelector } from 'src/lib/hooks'
-import { MemberFormParam } from 'src/lib/types/UserInterface'
 import { AiOutlineWarning } from 'react-icons/ai'
+import { memberAPI } from 'src/lib/api/Member/MemberAPI'
 import * as S from './styles'
-
-const initialEditForm = {
-  profileUrl: '',
-  imageFile: null,
-  username: '',
-  imageUrl: '',
-} as Omit<MemberFormParam, 'email' & 'password'>
 
 const MemberProfile = () => {
   const dispatch = useAppDispatch()
   const { memberInfo } = useAppSelector(({ member }) => member.value)
   const imgInputRef = useRef<HTMLInputElement>(null)
+  const initialEditForm = {
+    profileUrl: '',
+    imageFile: {},
+    username: memberInfo.username,
+    imageUrl: memberInfo.imageUrl,
+  }
   const [memberForm, setMemberForm] = useState(initialEditForm)
   const [isOpenEdit, setIsOpenEdit] = useState(false)
 
@@ -25,17 +24,13 @@ const MemberProfile = () => {
     imgInputRef.current?.click()
   }
 
-  const onChangeProfileImg = useCallback(
-    async (e: ChangeEvent<HTMLElement>) => {
-      const ImageFiles = (e.target as HTMLInputElement).files
-      if (ImageFiles && ImageFiles[0]) {
-        const url = URL.createObjectURL(ImageFiles[0])
-        setMemberForm({ ...memberForm, imageFile: ImageFiles[0] })
-        setMemberForm({ ...memberForm, imageUrl: url })
-      }
-    },
-    [imgInputRef],
-  )
+  const onChangeProfileImg = (e: ChangeEvent<HTMLElement>) => {
+    const ImageFiles = (e.target as HTMLInputElement).files
+    if (ImageFiles && ImageFiles[0]) {
+      const url = URL.createObjectURL(ImageFiles[0])
+      setMemberForm({ ...memberForm, imageFile: ImageFiles[0], imageUrl: url })
+    }
+  }
 
   const onClickRemoveButton = useCallback(() => {
     setMemberForm({ ...memberForm, imageUrl: memberInfo.imageUrl })
@@ -47,7 +42,8 @@ const MemberProfile = () => {
 
   const onSubmitUserForm = async (e: FormEvent<HTMLFormElement>) => {
     e.preventDefault()
-    await dispatch(postEditedMember(memberForm))
+    const form = { username: memberForm.username, imageFile: memberForm.imageFile }
+    await memberAPI.postMemberInfo(form)
     setIsOpenEdit(false)
     dispatch(changeMemberInfo({ key: 'username', value: memberForm.username }))
     dispatch(changeMemberInfo({ key: 'imageUrl', value: memberForm.imageUrl }))
@@ -104,7 +100,7 @@ const MemberProfile = () => {
     <>
       <S.Profile>
         <S.Thumbnail>
-          <S.MemberImage image={memberInfo.imageUrl} />
+          <S.MemberImage image={memberForm.imageUrl} />
         </S.Thumbnail>
         <S.MemberInfo>
           <S.Name>{memberInfo.username}</S.Name>

--- a/src/lib/api/Member/MemberAPI.ts
+++ b/src/lib/api/Member/MemberAPI.ts
@@ -1,6 +1,5 @@
 import decodeJWT from 'src/lib/util/decodeJWT'
 import { EDIT_MEMBER_URL, USER_URL } from 'src/lib/constants/Url'
-import { MemberFormParam } from 'src/lib/types/UserInterface'
 import HttpClient from '../httpClient'
 
 class MemberAPI extends HttpClient {
@@ -19,18 +18,14 @@ class MemberAPI extends HttpClient {
     return response.data
   }
 
-  public postMemberInfo = async (data: Omit<MemberFormParam, 'email' & 'password'>) => {
-    const formData = new FormData()
-    if (data.imageFile) formData.append('imageFile', data.imageFile)
+  public postMemberInfo = async (data: { username: string; imageFile: File | object }) => {
     const params = new URLSearchParams()
     params.append('username', data.username)
-
-    const response = this.instance.post(
+    this.instance.post(
       EDIT_MEMBER_URL,
       { imageFile: data.imageFile },
       { headers: { 'Content-Type': 'multipart/form-data' }, params },
     )
-    return response
   }
 
   public deleteMember = () => {

--- a/src/lib/api/Member/SignUpAPI.ts
+++ b/src/lib/api/Member/SignUpAPI.ts
@@ -46,8 +46,9 @@ class SignUpAPI extends HttpClient {
     }
   }
 
-  public SignUp = (data: Omit<MemberFormParam, 'profileUrl' | 'imageUrl'>) =>
+  public SignUp = (data: Omit<MemberFormParam, 'profileUrl' | 'imageUrl'>) => {
     this.instance.post(SIGNUP_URL, data, { headers: { 'Content-Type': 'multipart/form-data' } })
+  }
 }
 
 const signUpAPI = new SignUpAPI()

--- a/src/lib/store/member/memberFormSlice.ts
+++ b/src/lib/store/member/memberFormSlice.ts
@@ -4,7 +4,7 @@ import { MemberFormParam } from 'src/lib/types/UserInterface'
 
 const initialMemberForm = {
   memberForm: {
-    imageFile: null,
+    imageFile: {},
     username: '',
     email: '',
     password: '',

--- a/src/lib/store/member/memberSlice.ts
+++ b/src/lib/store/member/memberSlice.ts
@@ -34,13 +34,13 @@ export const getMemberInfo = createAsyncThunk('member/getMember', async () => {
   return response
 })
 
-export const postEditedMember = createAsyncThunk(
-  'editMember/postMember',
-  async (memberForm: Omit<MemberFormParam, 'email' & 'password'>) => {
-    const response = await memberAPI.postMemberInfo(memberForm)
-    return response
-  },
-)
+// export const postEditedMember = createAsyncThunk(
+//   'editMember/postMember',
+//   async (memberForm: Omit<MemberFormParam, 'email' & 'password'>) => {
+//     const response = await memberAPI.postMemberInfo(memberForm)
+//     return response
+//   },
+// )
 
 export const getStudiesAppliedFor = createAsyncThunk('member/getstudiesAppliedFor', async () => {
   const response = await studyAPI.getStudiesAppliedFor()

--- a/src/lib/types/UserInterface.ts
+++ b/src/lib/types/UserInterface.ts
@@ -10,7 +10,7 @@ export interface ValidationParam extends SignInParam {
 export interface MemberFormParam extends ValidationParam {
   profileUrl: string | null
   imageUrl: string
-  imageFile: File | null | string
+  imageFile: File | null
 }
 
 export interface ParticipateParam {


### PR DESCRIPTION
## 🔎 What is this PR?

- 프로필 수정 폼에 useState를 사용했는데 imageFile의 변경 내용이 적용되지 않는 문제가 발생했습니다.

## 🔑 Key Changes

### 📄 useState 비동기 처리 문제
* setState를 두번 연속 호출해 비동기적으로 처리가 진행되어, 마지막 setState호출분만 적용되었기 때문에 imageFile 데이터의 변경이 적용되지 않았습니다.

#### 💾  [components/member/MemberProfile.tsx]
✔ 문제가 된 부분
```ts
 setMemberForm({ ...memberForm, imageFile: ImageFiles[0] })
 setMemberForm({ ...memberForm, imageUrl: url })
```

✔ 변경된 부분
* setState를 한번만 호출해 함수내 useState에 관한 비동기 처리가 발생하지 않도록 작성했습니다.
```ts
setMemberForm({ ...memberForm, imageFile: ImageFiles[0], imageUrl: url })
```
## 🙋🏻‍♀️ To Reviewers
해당 trouble shooting에 관해 작성한 포스트입니다.

🔗[useState 비동기 에러 처리하기](https://sj0826.github.io/coding-swamp/projects-codingswamp-useState-asynchronous/)
